### PR TITLE
Fix dockerised funnel

### DIFF
--- a/DemoStack/.env
+++ b/DemoStack/.env
@@ -74,7 +74,7 @@ MinioBrowser=http://localhost:9000 # MinioServerApi=http://127.0.0.1:9000
 TesAPIUrl=http://funnel:8000/v1/tasks # Where TESK or Funnel API is hosted:
 FunnelMinioUser=miniofunnel
 FunnelMinioPass=miniofunnel
-FUNNEL_VERSION=v0.11.8
+FUNNEL_VERSION=v0.11.12
 TesOutputBucketPrefix=s3:// # Output bucket prefix for the TES executing agent to write results to
 
 IgnoreHutchSSL=true

--- a/ServiceStack/compose-manifests/tes/funnel/Dockerfile
+++ b/ServiceStack/compose-manifests/tes/funnel/Dockerfile
@@ -1,13 +1,17 @@
-FROM docker:dind-rootless
+FROM golang:1.26-alpine AS builder
 ARG FUNNEL_VERSION
 
+RUN apk add --no-cache git make bash
+WORKDIR /build
+RUN git clone https://github.com/calypr/funnel.git .
+RUN git checkout tags/${FUNNEL_VERSION}
+RUN go build -o bin/funnel .
+
+FROM docker:dind-rootless
+
 USER root
-RUN apk add --no-cache curl perl-utils \
-    && sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohsu-comp-bio/funnel/refs/heads/develop/install.sh)" -- ${FUNNEL_VERSION} \
-    && cp /root/.local/bin/funnel /usr/local/bin/funnel \
-    && chown rootless:rootless /usr/local/bin/funnel \
-    && chmod +x /usr/local/bin/funnel \
-    && apk del curl perl-utils 
+COPY --from=builder /build/bin/funnel /usr/local/bin/funnel
+RUN chown rootless:rootless /usr/local/bin/funnel && chmod +x /usr/local/bin/funnel
 USER rootless
 
 # Set data dir

--- a/ServiceStack/compose-manifests/tes/funnel/config.template.yaml
+++ b/ServiceStack/compose-manifests/tes/funnel/config.template.yaml
@@ -2,10 +2,6 @@ Database: boltdb
 
 Compute: local
 
-Logger:
-  Level: info
-  OutputFile: ""
-
 Server:
   HTTPPort: "8000"
   RPCPort: "9090"
@@ -23,9 +19,6 @@ BoltDB:
 
 AmazonS3:
   Disabled: true
-  MaxRetries: 10
-  Key: ""
-  Secret: ""
 
 GenericS3:
   - Disabled: false

--- a/ServiceStack/compose-manifests/tes/tes.yml
+++ b/ServiceStack/compose-manifests/tes/tes.yml
@@ -1,6 +1,6 @@
 services:
   dind:
-    image: docker:dind
+    image: docker:20-dind
     privileged: true
     command: dockerd --host=tcp://0.0.0.0:2375
     healthcheck:
@@ -42,6 +42,7 @@ services:
       - MinioKey=${FunnelMinioUser} 
       - MinioSecret=${FunnelMinioPass}
       - DOCKER_HOST=tcp://dind:2375
+      - DOCKER_API_VERSION=1.41
     networks:
       - sub-net
     volumes:


### PR DESCRIPTION
Changes:
- Applied [five-safes-tes.patch](https://github.com/UoMResearchIT/RTP-396-nwcybercomm/blob/main/Codes/tre_service/five-safes-tes.patch)
- Updated org name in git clone
- Updated to checkout tags instead of the dev branch
- Updated FUNNEL_VERSION to v0.11.12 to fix issues caused by v0.11.8 using the old org name `ohsu-comp-bio`